### PR TITLE
Make stderr redirection compatible with Fish 3.0.

### DIFF
--- a/fish_prompt.fish
+++ b/fish_prompt.fish
@@ -2,14 +2,14 @@
 # Find latest version from: https://github.com/godfat/fish_prompt-gitstatus
 
 function _git_branch_name
-  echo (command git symbolic-ref HEAD ^/dev/null | sed -e 's|^refs/heads/||')
+  echo (command git symbolic-ref HEAD 2> /dev/null | sed -e 's|^refs/heads/||')
 end
 
 function _git_status_symbol
-  set -l git_status (git status --porcelain ^/dev/null)
+  set -l git_status (git status --porcelain 2> /dev/null)
   if test -n "$git_status"
     # Is there anyway to preserve newlines so we can reuse $git_status?
-    if git status --porcelain ^/dev/null | grep '^.[^ ]' >/dev/null
+    if git status --porcelain 2> /dev/null | grep '^.[^ ]' >/dev/null
       echo '*' # dirty
     else
       echo '#' # all staged


### PR DESCRIPTION
Fish has deprecated `^` as a shortcut for stderr redirection in 3.0. Replace it with the more
compatible `2>`.

See oh-my-fish/oh-my-fish#609 and oh-my-fish/oh-my-fish#618